### PR TITLE
Made Packed entities equatable

### DIFF
--- a/src/entities.cs
+++ b/src/entities.cs
@@ -85,7 +85,7 @@ namespace Leopotam.EcsLite {
 #endif
         public bool Equals(EcsPackedEntityWithWorld other)
         {
-            return Id == other.Id && Gen == other.Gen && Equals(World, other.World);
+            return Id == other.Id && Gen == other.Gen && World == other.World;
         }
 
 

--- a/src/entities.cs
+++ b/src/entities.cs
@@ -132,7 +132,7 @@ namespace Leopotam.EcsLite {
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public static bool EqualsTo (this in EcsPackedEntity a, in EcsPackedEntity b) {
-            return a.Id == b.Id && a.Gen == b.Gen;
+            return a.Equals(b);
         }
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
@@ -157,8 +157,9 @@ namespace Leopotam.EcsLite {
         }
 
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
-        public static bool EqualsTo (this in EcsPackedEntityWithWorld a, in EcsPackedEntityWithWorld b) {
-            return a.Id == b.Id && a.Gen == b.Gen && a.World == b.World;
+        public static bool EqualsTo (this in EcsPackedEntityWithWorld a, in EcsPackedEntityWithWorld b)
+        {
+			return a.Equals(b);
         }
     }
 }

--- a/src/entities.cs
+++ b/src/entities.cs
@@ -159,7 +159,7 @@ namespace Leopotam.EcsLite {
         [MethodImpl (MethodImplOptions.AggressiveInlining)]
         public static bool EqualsTo (this in EcsPackedEntityWithWorld a, in EcsPackedEntityWithWorld b)
         {
-			return a.Equals(b);
+            return a.Equals(b);
         }
     }
 }

--- a/src/entities.cs
+++ b/src/entities.cs
@@ -4,6 +4,7 @@
 // Copyright (c) 2021-2022 Leopotam <leopotam@gmail.com>
 // ----------------------------------------------------------------------------
 
+using System;
 using System.Runtime.CompilerServices;
 
 #if ENABLE_IL2CPP
@@ -11,12 +12,36 @@ using Unity.IL2CPP.CompilerServices;
 #endif
 
 namespace Leopotam.EcsLite {
-    public struct EcsPackedEntity {
+    public struct EcsPackedEntity :IEquatable<EcsPackedEntity> {
         internal int Id;
         internal int Gen;
+
+
+        public bool Equals(EcsPackedEntity other)
+        {
+            return Id == other.Id && Gen == other.Gen;
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            return obj is EcsPackedEntity other && Equals(other);
+        }
+
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Gen);
+        }
+        
+        public static bool operator ==(EcsPackedEntity left, EcsPackedEntity right) =>
+            Equals(left, right);
+
+        public static bool operator !=(EcsPackedEntity left, EcsPackedEntity right) =>
+            !Equals(left, right);
     }
 
-    public struct EcsPackedEntityWithWorld {
+    public struct EcsPackedEntityWithWorld :IEquatable<EcsPackedEntityWithWorld> {
         internal int Id;
         internal int Gen;
         internal EcsWorld World;
@@ -58,6 +83,28 @@ namespace Leopotam.EcsLite {
             return $"Entity-{Id}:{Gen} [{sb}]";
         }
 #endif
+        public bool Equals(EcsPackedEntityWithWorld other)
+        {
+            return Id == other.Id && Gen == other.Gen && Equals(World, other.World);
+        }
+
+
+        public override bool Equals(object obj)
+        {
+            return obj is EcsPackedEntityWithWorld other && Equals(other);
+        }
+
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Id, Gen, World);
+        }
+        
+        public static bool operator ==(EcsPackedEntityWithWorld left, EcsPackedEntityWithWorld right) =>
+            Equals(left, right);
+
+        public static bool operator !=(EcsPackedEntityWithWorld left, EcsPackedEntityWithWorld right) =>
+            !Equals(left, right);
     }
 
 #if ENABLE_IL2CPP


### PR DESCRIPTION
Made Packed Entities equatable, such that they can be stored in generic containers.


Structs have a default equality implementation that compares members.  However, it is inefficient, and causes value boxing.  If EcsPackedEntity or EcsPackedEntityWithWorld are stored in generic collections (such as might done if used in an Event listening system), each comparison done by the containers will cause memory hits.

This request overrides the default implementation, as well as adds an IEquatable implementation (which the built-in collection will use if present) to avoid this issue.

Further reading:
Technical discussion: [here](https://devblogs.microsoft.com/premier-developer/performance-implications-of-default-struct-equality-in-c/)
Shorter read with implementation model [here](https://montemagno.com/optimizing-c-struct-equality-with-iequatable/)

